### PR TITLE
feat: ToString() for std::filesystem::path

### DIFF
--- a/libraries/common/include/format.hpp
+++ b/libraries/common/include/format.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <filesystem>
 #include <type_traits>
 #include <string>
 #include <sstream>
@@ -45,6 +46,11 @@ inline std::string ToString<std::string>(const std::string& value) {
 template<>
 inline std::string ToString<std::string_view>(const std::string_view& value) {
     return std::string(value);
+}
+
+template<>
+inline std::string ToString<std::filesystem::path>(const std::filesystem::path& path) {
+    return path.string();
 }
 
 template<>

--- a/libraries/common/tests/format.cpp
+++ b/libraries/common/tests/format.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <filesystem>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -38,6 +39,12 @@ TEST_CASE("ToString", "[Format]") {
     SECTION("String") {
         CheckString(ToString("hello"), "hello");
         CheckString(ToString(std::string("hello")), "hello");
+        CheckString(ToString(std::string_view("hello")), "hello");
+    }
+
+    SECTION("Path") {
+        CheckString(ToString(std::filesystem::path("/tmp/data/modoule.file")),
+                    "/tmp/data/modoule.file");
     }
 
     SECTION("Timepoint") {

--- a/services/document_db/src/fs_sink/fs_sink.cpp
+++ b/services/document_db/src/fs_sink/fs_sink.cpp
@@ -35,7 +35,7 @@ auto OpenMetaFileIn(const std::filesystem::path& path) {
     } catch (const std::ios_base::failure& ex) {
         throw exceptions::FilesystemException(common::format::Format(
             "Cannot open index file {}: {}",
-            path.string(), ex.what()));
+            path, ex.what()));
     }
 }
 
@@ -45,7 +45,7 @@ auto OpenMetaFileOut(const std::filesystem::path& path) {
     } catch (const std::ios_base::failure& ex) {
         throw exceptions::FilesystemException(common::format::Format(
             "Cannot open index file {}: {}",
-            path.string(), ex.what()));
+            path, ex.what()));
     }
 }
 
@@ -63,7 +63,7 @@ std::unordered_map<size_t, PageFile> LoadPageFilesMap(const std::filesystem::pat
         }
 
         PageFile page(item.path());
-        LOG_DEBUG() << "Found data page " << page.Path().string() << " of size " << page.Size();
+        LOG_DEBUG() << "Found data page " << page.Path() << " of size " << page.Size();
         files_map.insert({page.Index(), std::move(page)});
     }
     return files_map;
@@ -206,8 +206,7 @@ models::DocumentPayloadPtr FileStorageSink::LoadPayload(const models::DocumentPo
 }
 
 void FileStorageSink::InitFs() {
-    LOG_INFO() << "Init document DB file system storage at "
-               << meta_path_.generic_string();
+    LOG_INFO() << "Init document DB file system storage at " << meta_path_;
 
     const auto is_index_exists = std::filesystem::exists(meta_path_);
     if (!is_index_exists) {

--- a/services/document_db/src/fs_sink/page.cpp
+++ b/services/document_db/src/fs_sink/page.cpp
@@ -24,7 +24,7 @@ size_t GetPageSize(const std::filesystem::path& path) {
         return std::filesystem::file_size(path);
     } catch (const std::filesystem::filesystem_error& ex) {
         LOG_ERROR() << common::format::Format(
-            "Cannot obtain page size for file {}: {}", path.string(), ex.what());
+            "Cannot obtain page size for file {}: {}", path, ex.what());
         throw exceptions::FilesystemException();
     }
 }
@@ -35,7 +35,7 @@ size_t GetPageIndex(const std::filesystem::path& path) {
         return std::stol(stem.substr(kPageFilePrefix.size()));
     } catch (const std::logic_error& ex) {
         LOG_ERROR() << common::format::Format(
-            "Cannot obtain page index for file {}: {}", path.string(), ex.what());
+            "Cannot obtain page index for file {}: {}", path, ex.what());
         throw exceptions::FilesystemException();
     }
 }
@@ -46,11 +46,11 @@ void CheckPageValidity(const std::filesystem::path& path) {
         std::string buffer;
         file >> buffer;
         if (buffer != kPagePrefix) {
-            LOG_ERROR() << path.string() << " file is corrupted; found prefix \"" << buffer << "\"";
+            LOG_ERROR() << path << " file is corrupted; found prefix \"" << buffer << "\"";
             throw exceptions::FilesystemException();
         }
     } catch(const std::ios_base::failure& ex) {
-        LOG_ERROR() << "I/O error on file " << path.string() << ": " << ex.what();
+        LOG_ERROR() << "I/O error on file " << path << ": " << ex.what();
         throw exceptions::FilesystemException();
     }
 }
@@ -88,7 +88,7 @@ void PageFile::Init() {
         CheckPageValidity(path_);
         size_ = GetPageSize(path_);
     } else {
-        LOG_DEBUG() << "Initializing new page at " << path_.string();
+        LOG_DEBUG() << "Initializing new page at " << path_;
         common::binary::BinaryOutStream stream(path_);
         stream << kPagePrefix;
         size_ = GetDefaultPageSize();
@@ -149,7 +149,7 @@ models::DocumentPayloadPtr PageFile::LoadPayload(size_t page_offset) {
     file >> is_active;
     if (!is_active) {
         LOG_ERROR() << "Document info points to an unactive payload: "
-                    << path_.string() << ":" << page_offset;
+                    << path_ << ":" << page_offset;
         throw exceptions::FilesystemException();
     }
     models::DocumentPayload payload;


### PR DESCRIPTION
Added a new overload for `common::format::ToString()` with `std::filesystem::path` type. All usages refactored.